### PR TITLE
Fix jitpack build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("org.sonarqube") version "3.3"
     jacoco
     id("com.github.hierynomus.license") version "0.16.1"
+    `maven-publish`
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("org.sonarqube") version "3.3"
     jacoco
     id("com.github.hierynomus.license") version "0.16.1"
+    `java-library`
     `maven-publish`
 }
 
@@ -75,3 +76,21 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
         }
     }
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("kotlin-hsdp-api") {
+            from(components["kotlin"])
+            pom {
+                licenses {
+                    license {
+                        name.set("The MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                        distribution.set("repo")
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.philips.hsdp.apis
 kotlin.code.style = official
-version = 0.1.1-SNAPSHOT
+version = 0.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.philips.hsdp.apis
 kotlin.code.style = official
-version = 0.2.0-SNAPSHOT
+version = 0.1.1-SNAPSHOT


### PR DESCRIPTION
jitpack requires maven or maven-publish plugin to be used in the gradle file, so that it can use "install" or "publishToMavenLocal" task to generate/publish the library. Next to that a publishing configuration is needed.